### PR TITLE
[HUST CSE] a variable is used directly without assigning an initial value

### DIFF
--- a/Library/StdDriver/src/rng.c
+++ b/Library/StdDriver/src/rng.c
@@ -50,7 +50,7 @@ static void RNG_BasicConfig()
 {
     int32_t i;
     int32_t timeout = 0x1000000;
-
+    i = 0;
     /* Enable TRNG & PRNG */
     CLK->AHBCLK0 |= CLK_AHBCLK0_CRPTCKEN_Msk;
     CLK->APBCLK1 |= CLK_APBCLK1_TRNGCKEN_Msk;
@@ -80,7 +80,7 @@ int32_t RNG_Open()
 {
     int32_t i;
     int32_t timeout = 0x1000000;
-    
+ 
     RNG_BasicConfig();
     
     /* TRNG Activate */


### PR DESCRIPTION
#### 1.这个PR修复的是什么问题？
源码  ： 
```
static void RNG_BasicConfig()
{
    int32_t i;
    int32_t timeout = 0x1000000;

    /* Enable TRNG & PRNG */
    CLK->AHBCLK0 |= CLK_AHBCLK0_CRPTCKEN_Msk;
    CLK->APBCLK1 |= CLK_APBCLK1_TRNGCKEN_Msk;

    /* Use LIRC as TRNG engine clock */
    CLK->PWRCTL |= CLK_PWRCTL_LIRCEN_Msk;
    while ((CLK->STATUS & CLK_STATUS_LIRCSTB_Msk) == 0)
    {
        if (i++ > timeout) break; /* Wait LIRC time-out */
    }
    CLK->CLKSEL2 = (CLK->CLKSEL2 & (~CLK_CLKSEL2_TRNGSEL_Msk)) | CLK_CLKSEL2_TRNGSEL_LIRC;

}
```
本段中，i未赋初值即进行i++操作
#### 2.这个PR不修复具体会带来什么后果？
i在未赋初值的情况下执行i++，存在较大风险
#### 3.PR修复方案的依据是什么？
在原函数的基础上，添加i的初值，保证了代码的安全性：
`i = 0`
#### 4. 在什么环境下测试或者验证过？
all