### PR TITLE
A variable is used directly without assigning an initial value

### DIFF
--- a/Library/StdDriver/src/trng.c
+++ b/Library/StdDriver/src/trng.c
@@ -35,7 +35,7 @@
 int32_t TRNG_Open(void)
 {
     uint32_t u32TimeOutCount = SystemCoreClock; /* 1 second time-out */
-    uint32_t i;
+    uint32_t i = 0;
 
     SYS->IPRST1 |= SYS_IPRST1_TRNGRST_Msk;
     SYS->IPRST1 ^= SYS_IPRST1_TRNGRST_Msk;


### PR DESCRIPTION
A variable is used directly without assigning an initial value

'i' may be used uninitialized in this function.

本段中，i未赋初值即进行i++操作

这个PR不修复具体会带来什么后果？
i在未赋初值的情况下执行i++，存在较大风险

PR修复方案的依据是什么？
在原函数的基础上，添加i的初值，保证了代码的安全性：
i = 0
